### PR TITLE
Add federal initial disclosures worksheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # potential-octo-winner
+
 RMM#
+
+## Work
+
+- [Federal civil initial disclosures worksheet](docs/federal_initial_disclosures_worksheet.md)

--- a/docs/federal_initial_disclosures_worksheet.md
+++ b/docs/federal_initial_disclosures_worksheet.md
@@ -1,0 +1,165 @@
+# Federal Civil Initial Disclosures Worksheet
+
+> **Not legal advice.** This worksheet is a drafting aid for a federal **civil** case. Check the Federal Rules of Civil Procedure, your judge's orders, your district's local rules, and any scheduling order. If you have a lawyer, ask your lawyer before serving anything.
+
+## 1. Confirm this is the right disclosure
+
+Use this worksheet for **Federal Rule of Civil Procedure 26(a)(1) initial disclosures** in a civil case.
+
+Before drafting, confirm:
+
+- [ ] The case is not exempt from initial disclosures under Rule 26(a)(1)(B).
+- [ ] The court has not entered an order changing what must be disclosed.
+- [ ] The parties did not stipulate to a different deadline or format.
+- [ ] You have reviewed any local rules, standing orders, and the scheduling order.
+- [ ] You know the service deadline. In general, initial disclosures are due **14 days after the Rule 26(f) conference** unless a stipulation or court order sets another time.
+
+## 2. Case caption information
+
+Fill this in exactly as it appears on court filings.
+
+- **Court:** United States District Court for the __________ District of __________
+- **Division:** __________
+- **Plaintiff(s):** __________
+- **Defendant(s):** __________
+- **Case number:** __________
+- **Judge:** __________
+- **Magistrate judge:** __________
+- **Your name / party represented:** __________
+- **Disclosure date:** __________
+
+## 3. People with discoverable information
+
+Rule 26(a)(1)(A)(i) generally requires the name, address, and telephone number of each individual likely to have discoverable information that you may use to support your claims or defenses, unless the use would be solely for impeachment. Include the subjects of that information.
+
+| Person / entity | Address | Telephone | Subjects of information | Claim or defense supported |
+| --- | --- | --- | --- | --- |
+| __________ | __________ | __________ | __________ | __________ |
+| __________ | __________ | __________ | __________ | __________ |
+| __________ | __________ | __________ | __________ | __________ |
+
+Review prompts:
+
+- [ ] People who personally saw or heard relevant events.
+- [ ] People who communicated about the dispute.
+- [ ] People who created, received, or maintained relevant records.
+- [ ] Employers, supervisors, coworkers, customers, contractors, or agency representatives, if relevant.
+- [ ] Treating providers, repair providers, accountants, or other non-retained professionals, if relevant.
+
+## 4. Documents, electronically stored information, and tangible things
+
+Rule 26(a)(1)(A)(ii) generally requires a copy — or a description by category and location — of documents, electronically stored information, and tangible things that you have in your possession, custody, or control and may use to support your claims or defenses, unless the use would be solely for impeachment.
+
+| Category | Location / custodian | Format | Date range | Will produce copy now? |
+| --- | --- | --- | --- | --- |
+| __________ | __________ | __________ | __________ | Yes / No |
+| __________ | __________ | __________ | __________ | Yes / No |
+| __________ | __________ | __________ | __________ | Yes / No |
+
+Common categories to consider:
+
+- [ ] Contracts, policies, handbooks, applications, notices, letters, or forms.
+- [ ] Emails, texts, chats, voicemails, call logs, calendar entries, and social media messages.
+- [ ] Photographs, videos, audio recordings, screenshots, metadata, and device records.
+- [ ] Invoices, receipts, bank records, payroll records, tax records, and benefit records.
+- [ ] Medical, repair, inspection, incident, investigative, or agency records.
+- [ ] Physical objects, damaged property, products, samples, or demonstrative materials.
+
+Preservation reminders:
+
+- [ ] Do not delete or alter potentially relevant information.
+- [ ] Preserve phones, computers, cloud accounts, email accounts, paper files, and physical evidence.
+- [ ] Consider whether privileged or protected material should be logged rather than produced.
+
+## 5. Damages computation
+
+Rule 26(a)(1)(A)(iii) generally requires a computation of each category of damages you claim, along with documents or other evidentiary material on which each computation is based, unless privileged or protected from disclosure.
+
+| Damages category | Formula / computation | Amount | Supporting documents |
+| --- | --- | --- | --- |
+| __________ | __________ | $__________ | __________ |
+| __________ | __________ | $__________ | __________ |
+| __________ | __________ | $__________ | __________ |
+
+Prompts for possible categories, depending on your claims:
+
+- [ ] Lost wages, salary, commissions, overtime, bonuses, or benefits.
+- [ ] Out-of-pocket expenses, replacement costs, repair costs, or medical expenses.
+- [ ] Contract damages, unpaid invoices, interest, late fees, or mitigation costs.
+- [ ] Emotional distress, pain and suffering, statutory damages, punitive damages, or attorney's fees, if legally available.
+- [ ] Any offsets, payments received, mitigation earnings, or amounts no longer claimed.
+
+Calculation notes:
+
+- Explain the math plainly enough that the other side can understand how you reached the number.
+- Identify the documents supporting the computation, even if the final amount may need supplementation later.
+- If an amount is still being investigated, say what is known now and what information is missing.
+
+## 6. Insurance agreements
+
+Rule 26(a)(1)(A)(iv) generally requires disclosure of any insurance agreement under which an insurance business may be liable to satisfy all or part of a possible judgment or to indemnify or reimburse payments made to satisfy the judgment.
+
+| Insurer | Policy number | Coverage type | Limits / relevant terms | Copy attached? |
+| --- | --- | --- | --- | --- |
+| __________ | __________ | __________ | __________ | Yes / No / N/A |
+
+If you do not know of any responsive insurance agreement, write that after a reasonable inquiry you are not aware of any such agreement.
+
+## 7. Draft disclosure shell
+
+Use or adapt the following structure. Replace every bracketed item.
+
+```text
+[CAPTION]
+
+[PARTY NAME]'S INITIAL DISCLOSURES UNDER FEDERAL RULE OF CIVIL PROCEDURE 26(a)(1)
+
+Pursuant to Federal Rule of Civil Procedure 26(a)(1), [party name] provides the following initial disclosures based on information reasonably available at this time. These disclosures are made without waiving any objections, privileges, immunities, or protections, and may be supplemented under Rule 26(e).
+
+I. Individuals Likely to Have Discoverable Information
+
+1. [Name, address, telephone number] — [subjects of information].
+
+II. Documents, Electronically Stored Information, and Tangible Things
+
+[Party name] may use the following documents, electronically stored information, or tangible things to support its claims or defenses, unless used solely for impeachment:
+
+1. [Category and location, or identify copies being produced].
+
+III. Computation of Damages
+
+[Party name] currently computes damages as follows:
+
+1. [Category]: [calculation] = [$ amount]. Supporting materials include [documents/materials].
+
+IV. Insurance Agreements
+
+[State applicable insurance agreements, attach or identify copies, or state that none are known after reasonable inquiry.]
+
+Dated: [date]
+
+Respectfully submitted,
+
+[Signature block]
+```
+
+## 8. Service checklist
+
+- [ ] Sign the disclosures. Rule 26 disclosures must be in writing, signed, and served.
+- [ ] Serve the disclosures on every other party by the method allowed in the case.
+- [ ] Keep proof of service.
+- [ ] Do not file disclosures on the public docket unless a rule or court order requires filing.
+- [ ] Calendar a reminder to supplement or correct the disclosures if you later learn they are incomplete or incorrect in a material respect.
+
+## 9. Questions to answer before finalizing
+
+1. What claims or defenses are you trying to support with each witness and document category?
+2. Are any witnesses or documents listed only for impeachment? If so, they may not belong in initial disclosures.
+3. Have you separated privileged or protected material from materials that should be disclosed or produced?
+4. Can another person reproduce your damages math from the disclosure and supporting records?
+5. Does any judge-specific order require additional categories, a particular format, or an earlier deadline?
+
+## Sources checked
+
+- Federal Rule of Civil Procedure 26, including Rule 26(a)(1) initial disclosures and Rule 26(e) supplementation: <https://www.law.cornell.edu/rules/frcp/rule_26>
+- United States Courts current Federal Rules of Civil Procedure page, noting amendments effective December 1, 2025: <https://www.uscourts.gov/rules-policies/current-rules-practice-procedure/federal-rules-civil-procedure>


### PR DESCRIPTION
### Motivation
- Provide a practical, portable drafting aid for Federal Rule of Civil Procedure 26(a)(1) initial disclosures to help assemble witnesses, documents/ESI, damages calculations, and insurance information.
- Make the worksheet discoverable by linking it from the project `README.md`.

### Description
- Add `docs/federal_initial_disclosures_worksheet.md` containing a Rule 26(a)(1) checklist, case-caption template, tables for people and document categories, damages computation guidance, insurance disclosure section, a reusable draft disclosure shell, preservation reminders, and source links.
- Update `README.md` to include a link to the new worksheet at `docs/federal_initial_disclosures_worksheet.md`.
- Include a clear "Not legal advice" notice and cite the checked sources (Rule 26 and the U.S. Courts rules page).

### Testing
- Ran a documentation smoke check with the command `python3 - <<'PY' ... PY` that verifies the new file exists and contains key section headings (`Rule 26(a)(1)`, `People with discoverable information`, `Damages computation`, `Insurance agreements`, `Service checklist`), and it passed.
- No unit or integration tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d76eae348832cb065dfd451f7f067)